### PR TITLE
Modificações maven

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,5 @@ local.properties
 # Uncomment this line if you wish to ignore the project description file.
 # Typically, this file would be tracked if it contains build/dependency configurations:
 .project
+target/
+.vscode/settings.json

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,8 @@
   </dependencies>
 
   <build>
-    <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->
+    <pluginManagement>
+      <!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->
       <plugins>
         <!-- clean lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#clean_Lifecycle -->
         <plugin>
@@ -51,6 +52,13 @@
         <plugin>
           <artifactId>maven-jar-plugin</artifactId>
           <version>3.0.2</version>
+          <configuration>
+            <archive>
+              <manifest>
+                <mainClass>com.ifgrupo.application.Program</mainClass>
+              </manifest>
+            </archive>
+          </configuration>
         </plugin>
         <plugin>
           <artifactId>maven-install-plugin</artifactId>


### PR DESCRIPTION
# Modificações
- Adicionado `target/` e `.vscode` ao `.gitignore`
- Adicionado caminho da classe ao maven
    - Isso habilita a execução do `.jar` de forma independente, sem ter que colocar o caminho da classe principal na linha de comando
    - É possível automatizar esse processo de colocar o caminho da classe principal no `pom.xml`?